### PR TITLE
fix: npm package name cannot start with underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "-notebook": "file:src/notebook",
+    "aaa_notebook": "file:src/notebook",
     "@observablehq/runtime": "^4.4.1",
     "build": "^0.1.4",
     "d3": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "_notebook": "file:src/notebook",
+    "-notebook": "file:src/notebook",
     "@observablehq/runtime": "^4.4.1",
     "build": "^0.1.4",
     "d3": "^5.11.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 // Import Observable notebook
-import notebook from '-notebook';
+import notebook from 'aaa_notebook';
 import * as fetchAlias from './fetchAlias.json';
 
 // intercept and reroute calls

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 // Import Observable notebook
-import notebook from '_notebook';
+import notebook from '-notebook';
 import * as fetchAlias from './fetchAlias.json';
 
 // intercept and reroute calls

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,6 @@
 # yarn lockfile v1
 
 
-"-notebook@file:src/notebook":
-  version "633.0.0"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -170,6 +167,9 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"aaa_notebook@file:src/notebook":
+  version "633.0.0"
 
 acorn@^7.0.0:
   version "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,9 @@
 # yarn lockfile v1
 
 
+"-notebook@file:src/notebook":
+  version "633.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -167,9 +170,6 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
-
-"_notebook@file:src/notebook":
-  version "633.0.0"
 
 acorn@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
> The name can’t start with a dot or an underscore.

https://docs.npmjs.com/files/package.json#name