### PR TITLE
fix: fix deployment to now.sh

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,4 +1,5 @@
 node_modules/
 public/
 vendor/
+package-lock.json
 yarn.lock

--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,4 @@
+node_modules/
+public/
+vendor/
+yarn.lock

--- a/now.json
+++ b/now.json
@@ -1,0 +1,9 @@
+{
+  "builds": [
+    {
+      "src": "now.sh",
+      "use": "@now/static-build",
+      "config": { "distDir": "public" }
+    }
+  ]
+}

--- a/now.sh
+++ b/now.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn notebook && yarn --ignore-optional && yarn data && yarn build:light
+yarn notebook && yarn --ignore-optional && yarn data && yarn build

--- a/now.sh
+++ b/now.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yarn notebook && yarn --ignore-optional && yarn data && yarn build:light

--- a/now.sh
+++ b/now.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn notebook && yarn --ignore-optional && yarn data && yarn build
+yarn notebook && yarn && yarn data && yarn build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Standalone version of the Spherical contours notebook",
   "main": "index.js",
   "scripts": {
-    "build": "rollup -c && cp src/index.html public/",
+    "build": "rollup -c && cp src/index.html public/ && cp src/favicon.ico public/",
     "clean": "rm -rf node_modules public vendor",
     "data": "rm -rf public/data && mkdir -p public/data && node bin/download-data.js",
     "deploy": "now",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Standalone version of the Spherical contours notebook",
   "main": "index.js",
   "scripts": {
-    "build": "yarn setup && yarn build:light",
-    "build:light": "rollup -c && cp src/index.html public/",
+    "build": "rollup -c && cp src/index.html public/",
     "clean": "rm -rf node_modules public vendor",
     "data": "rm -rf public/data && mkdir -p public/data && node bin/download-data.js",
     "deploy": "now",
     "notebook": "rm -f vendor/notebook.tgz && mkdir -p vendor && curl -o vendor/notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/notebook.tgz",
-    "preserve": "yarn build:light",
+    "preserve": "yarn build",
     "serve": "http-server public/",
     "setup": "yarn notebook && yarn && yarn data",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -20,6 +19,9 @@
   },
   "custom": {
     "notebook": "https://api.observablehq.com/@fil/spherical-contours.tgz?v=3"
+  },
+  "engines": {
+    "node": ">=10.x"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- as package-lock.json is not present in the directory, the now.sh
static builder launches yarn install. Contrarily to npm install, it
installs the optionalDependencies by default, which caused an error.
- the build on now.sh is now done by the now.sh bash script, where we
have more control on which commands are run.
- note that we had to ignore the yarn.lock file to avoid a package
integrity problem when aaa_notebook is updated
- note also that now.sh requires node 10.x (see engines in package.json)