### PR TITLE
fix: ignore yarn cache when updating notebook package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "data": "rm -rf public/data && mkdir -p public/data && node bin/download-data.js",
     "deploy": "now",
     "notebook": "rm -f vendor/*notebook.tgz && timestamp=$(date \"+%s\") && mkdir -p vendor && curl -o vendor/${timestamp}_notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/${timestamp}_notebook.tgz",
+    "notebook:comment": "echo \"In 'notebook' script above, timestamp is a hack to avoid using local cache - see https://github.com/yarnpkg/yarn/issues/2165. No need for that with npm.\"",
     "preserve": "yarn build",
     "serve": "http-server public/",
     "setup": "yarn notebook && yarn && yarn data",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf node_modules public vendor",
     "data": "rm -rf public/data && mkdir -p public/data && node bin/download-data.js",
     "deploy": "now",
-    "notebook": "rm -f vendor/*.tgz && timestamp=$(date \"+%s\") && mkdir -p vendor && curl -o vendor/${timestamp}_notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/${timestamp}_notebook.tgz",
+    "notebook": "rm -f vendor/*notebook.tgz && timestamp=$(date \"+%s\") && mkdir -p vendor && curl -o vendor/${timestamp}_notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/${timestamp}_notebook.tgz",
     "preserve": "yarn build",
     "serve": "http-server public/",
     "setup": "yarn notebook && yarn && yarn data",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf node_modules public vendor",
     "data": "rm -rf public/data && mkdir -p public/data && node bin/download-data.js",
     "deploy": "now",
-    "notebook": "rm -f vendor/notebook.tgz && mkdir -p vendor && curl -o vendor/notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/notebook.tgz",
+    "notebook": "rm -f vendor/*.tgz && timestamp=$(date \"+%s\") && mkdir -p vendor && curl -o vendor/${timestamp}_notebook.tgz $npm_package_custom_notebook && yarn add --optional aaa_notebook@file:vendor/${timestamp}_notebook.tgz",
     "preserve": "yarn build",
     "serve": "http-server public/",
     "setup": "yarn notebook && yarn && yarn data",
@@ -42,6 +42,6 @@
     "rollup-plugin-terser": "^5.1.1"
   },
   "optionalDependencies": {
-    "aaa_notebook": "file:vendor/notebook.tgz"
+    "aaa_notebook": "file:vendor/1568386035_notebook.tgz"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,9 +196,9 @@
   dependencies:
     "@types/node" "*"
 
-"aaa_notebook@file:vendor/notebook.tgz":
+"aaa_notebook@file:vendor/1568386035_notebook.tgz":
   version "562.0.0"
-  resolved "file:vendor/notebook.tgz#db8f871fcb18fd66cfa377fc0142f7cb4aa074e2"
+  resolved "file:vendor/1568386035_notebook.tgz#cc7ad21fd0e650c6006b9d4c413b84797de54a2f"
 
 acorn@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
yarn doesn't have any mechanism yet to avoid using the cache when
installing a package (see https://github.com/yarnpkg/yarn/issues/2165).
But for local packages, we want to force install whan we download a new
version.
The trick here is to used a different filename for the tgz file... A
hack, not a solution.